### PR TITLE
Explicitly declare eos_name as public variable

### DIFF
--- a/EOS/breakout/actual_eos.f90
+++ b/EOS/breakout/actual_eos.f90
@@ -12,7 +12,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "gamma_law"  
+  character (len=64), public :: eos_name = "gamma_law"  
   
   double precision, save :: gamma_const
 

--- a/EOS/gamma_law_general/actual_eos.F90
+++ b/EOS/gamma_law_general/actual_eos.F90
@@ -17,7 +17,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "gamma_law_general"  
+  character (len=64), public :: eos_name = "gamma_law_general"  
   
   double precision, save :: gamma_const
   

--- a/EOS/helmholtz/actual_eos.F90
+++ b/EOS/helmholtz/actual_eos.F90
@@ -2,7 +2,7 @@ module actual_eos_module
 
     use eos_type_module
 
-    character (len=64) :: eos_name = "helmholtz"
+    character (len=64), public :: eos_name = "helmholtz"
 
     ! Runtime parameters
     logical, save :: do_coulomb

--- a/EOS/multigamma/actual_eos.f90
+++ b/EOS/multigamma/actual_eos.f90
@@ -15,7 +15,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "multigamma"
+  character (len=64), public :: eos_name = "multigamma"
   
   double precision :: gammas(nspec)
 

--- a/EOS/polytrope/actual_eos.f90
+++ b/EOS/polytrope/actual_eos.f90
@@ -31,7 +31,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "polytrope"
+  character (len=64), public :: eos_name = "polytrope"
   
   double precision, save :: gamma_const, K_const
   double precision, save :: mu_e

--- a/EOS/stellarcollapse/actual_eos.f90
+++ b/EOS/stellarcollapse/actual_eos.f90
@@ -8,7 +8,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "stellarcollapse"
+  character (len=64), public :: eos_name = "stellarcollapse"
   
   integer          :: max_newton = 100
 

--- a/EOS/ztwd/actual_eos.f90
+++ b/EOS/ztwd/actual_eos.f90
@@ -27,7 +27,7 @@ module actual_eos_module
 
   implicit none
 
-  character (len=64) :: eos_name = "ztwd"
+  character (len=64), public :: eos_name = "ztwd"
   
   double precision, private :: A, B, B2
   double precision, parameter, private :: iter_tol = 1.d-10


### PR DESCRIPTION
This was really only a problem for helmholtz, since `actual_eos_module` contained a `private` statement, but to be safe, make `eos_name` public in general.